### PR TITLE
Remove confusing date at end of README

### DIFF
--- a/README
+++ b/README
@@ -135,6 +135,3 @@ Download
 
     More development information is available at
     https://wiki.gnome.org/Apps/gthumb/development
-
-
-18 January 2010


### PR DESCRIPTION
The last line of the README states "18 January 2010", which creates the wrong impression that the GitHub repository is an hopelessly outdated mirror.

See also: https://bugzilla.gnome.org/show_bug.cgi?id=795126